### PR TITLE
Add initial Taylor-mode package and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Taylor Mode PINNs
+
+This repository provides a minimal Python package implementing basic routines for
+Taylor-mode automatic differentiation and a stub KFAC optimizer for
+Physics-informed neural networks (PINNs).
+
+The code is intentionally simple to act as a starting point for further
+development following the blueprint in `Plan.tex`.

--- a/notebooks/01_introduction_to_taylor_mode.ipynb
+++ b/notebooks/01_introduction_to_taylor_mode.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c826edaa",
+   "metadata": {},
+   "source": [
+    "# Introduction to Taylor-mode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61c3d624",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax.numpy as jnp\n",
+    "from taylor_mode import forward_derivatives"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c80bdc34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = lambda x: jnp.sin(x)\n",
+    "val, derivs = forward_derivatives(f, jnp.array(0.0), order=2)\n",
+    "print(\"value\", val)\n",
+    "print(\"first\", derivs[1])\n",
+    "print(\"second\", derivs[2])"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/06_simple_PINN_example.ipynb
+++ b/notebooks/06_simple_PINN_example.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "15bb9656",
+   "metadata": {},
+   "source": [
+    "# Simple PINN Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc8dfbcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from jax import random\n",
+    "from taylor_mode import forward_derivatives\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "916115cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# simple network\n",
+    "def net(params, x):\n",
+    "    for w, b in params[:-1]:\n",
+    "        x = jnp.tanh(x @ w + b)\n",
+    "    w, b = params[-1]\n",
+    "    return (x @ w + b).squeeze()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ad3e564",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "key = random.PRNGKey(0)\n",
+    "params = [\n",
+    "    (random.normal(key, (1, 10)), jnp.zeros(10)),\n",
+    "    (random.normal(key, (10, 1)), jnp.zeros(1)),\n",
+    "]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fed9b6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def f(x):\n",
+    "    return net(params, x)\n",
+    "\n",
+    "x0 = jnp.array([[0.0]])\n",
+    "val, derivs = forward_derivatives(f, x0, order=2)\n",
+    "print('u(x0)=', val)\n",
+    "print('du/dx=', derivs[1])\n",
+    "print('d2u/dx2=', derivs[2])\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/kron_utils/__init__.py
+++ b/src/kron_utils/__init__.py
@@ -1,0 +1,3 @@
+from .kfac import KFACOptimizer
+
+__all__ = ["KFACOptimizer"]

--- a/src/kron_utils/kfac.py
+++ b/src/kron_utils/kfac.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable
+import jax.numpy as jnp
+
+
+@dataclass
+class KFACOptimizer:
+    lr: float = 1e-3
+    damping: float = 1e-2
+
+    def step(self, params: Iterable[jnp.ndarray], grads: Iterable[jnp.ndarray]) -> Iterable[jnp.ndarray]:
+        """A dummy step that applies gradient descent."""
+        return [p - self.lr * g for p, g in zip(params, grads)]

--- a/src/pinns/__init__.py
+++ b/src/pinns/__init__.py
@@ -1,0 +1,3 @@
+from .operators import laplacian
+
+__all__ = ["laplacian"]

--- a/src/pinns/operators.py
+++ b/src/pinns/operators.py
@@ -1,0 +1,11 @@
+from typing import Callable
+import jax
+import jax.numpy as jnp
+from taylor_mode.forward import forward_derivatives
+
+
+def laplacian(f: Callable[[jnp.ndarray], jnp.ndarray], x: jnp.ndarray) -> jnp.ndarray:
+    """Compute Laplacian of scalar function at ``x`` using Taylor-mode."""
+    _, derivs = forward_derivatives(f, x, order=2)
+    hess = derivs[2]
+    return jnp.trace(hess)

--- a/src/taylor_mode/__init__.py
+++ b/src/taylor_mode/__init__.py
@@ -1,0 +1,11 @@
+from .jet import Jet
+from .forward import forward_derivatives
+from .randomize import stochastic_laplacian
+from .collapse import forward_derivatives_collapsed
+
+__all__ = [
+    "Jet",
+    "forward_derivatives",
+    "stochastic_laplacian",
+    "forward_derivatives_collapsed",
+]

--- a/src/taylor_mode/collapse.py
+++ b/src/taylor_mode/collapse.py
@@ -1,0 +1,8 @@
+from typing import Callable, Tuple, Dict
+import jax
+import jax.numpy as jnp
+
+
+def forward_derivatives_collapsed(f: Callable[[jnp.ndarray], jnp.ndarray], x: jnp.ndarray, order: int = 1) -> Tuple[jnp.ndarray, Dict[int, jnp.ndarray]]:
+    """Placeholder for collapsed Taylor-mode derivatives."""
+    return f(x), {}

--- a/src/taylor_mode/forward.py
+++ b/src/taylor_mode/forward.py
@@ -1,0 +1,32 @@
+from typing import Callable, Tuple, Dict
+import jax
+import jax.numpy as jnp
+from .jet import Jet
+
+
+def forward_derivatives(f: Callable[[jnp.ndarray], jnp.ndarray], x: jnp.ndarray, order: int = 1) -> Tuple[jnp.ndarray, Dict[int, jnp.ndarray]]:
+    """Compute derivatives of ``f`` at ``x`` up to ``order`` using JAX.
+
+    Parameters
+    ----------
+    f : Callable
+        Scalar-output function.
+    x : jnp.ndarray
+        Input array.
+    order : int
+        Highest derivative order to compute.
+
+    Returns
+    -------
+    value : jnp.ndarray
+        ``f(x)``.
+    derivs : Dict[int, jnp.ndarray]
+        Mapping from derivative order to derivative array.
+    """
+    value = f(x)
+    derivs: Dict[int, jnp.ndarray] = {}
+    if order >= 1:
+        derivs[1] = jax.jacfwd(f)(x)
+    if order >= 2:
+        derivs[2] = jax.jacfwd(jax.jacfwd(f))(x)
+    return value, derivs

--- a/src/taylor_mode/jet.py
+++ b/src/taylor_mode/jet.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Dict
+import jax.numpy as jnp
+
+@dataclass
+class Jet:
+    """Representation of a function's value and derivatives at a point."""
+
+    value: jnp.ndarray
+    derivatives: Dict[int, jnp.ndarray]

--- a/src/taylor_mode/randomize.py
+++ b/src/taylor_mode/randomize.py
@@ -1,0 +1,11 @@
+from typing import Callable
+import jax
+import jax.numpy as jnp
+from .forward import forward_derivatives
+
+
+def stochastic_laplacian(f: Callable[[jnp.ndarray], jnp.ndarray], x: jnp.ndarray, samples: int = 10) -> jnp.ndarray:
+    """Approximate Laplacian using random projections."""
+    v = jax.random.normal(jax.random.PRNGKey(0), (samples,) + x.shape)
+    hvp = jax.vmap(lambda v_i: jax.jvp(lambda z: forward_derivatives(f, z, order=2)[1][2], (x,), (v_i,))[1])(v)
+    return hvp.mean()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1,0 +1,9 @@
+import jax.numpy as jnp
+from taylor_mode import forward_derivatives
+
+def test_forward_derivatives():
+    f = lambda x: jnp.sin(x)
+    val, derivs = forward_derivatives(f, jnp.array(0.0), order=2)
+    assert jnp.allclose(val, 0.0)
+    assert jnp.allclose(derivs[1], 1.0)
+    assert jnp.allclose(derivs[2], 0.0)


### PR DESCRIPTION
## Summary
- implement minimal `taylor_mode` module with `Jet` and `forward_derivatives`
- add stub `kron_utils.KFACOptimizer`
- provide `pinns.laplacian` utility
- add example notebooks demonstrating derivative computation and a simple network
- create basic test for forward derivatives

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c52b0d9608333b87a70c3616b945c