### PR TITLE
Add hessian helper and stochastic laplacian demo

### DIFF
--- a/notebooks/09_stochastic_laplacian.ipynb
+++ b/notebooks/09_stochastic_laplacian.ipynb
@@ -1,0 +1,31 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "# Stochastic Laplacian Demo"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": ["import jax\n", "import jax.numpy as jnp\n", "from taylor_mode import stochastic_laplacian\n"]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": ["f = lambda x: jnp.sum(x**2)\n", "x0 = jnp.zeros(2)\n", "approx = stochastic_laplacian(f, x0, samples=50)\n", "print('approximate Laplacian:', approx)\n"]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,6 +3,7 @@
 from .taylor_mode import (
     Jet,
     forward_derivatives,
+    hessian,
     stochastic_laplacian,
     forward_derivatives_collapsed,
 )
@@ -12,6 +13,7 @@ from .pinns import gradient, laplacian, pinn_loss
 __all__ = [
     "Jet",
     "forward_derivatives",
+    "hessian",
     "pinn_loss",
     "stochastic_laplacian",
     "forward_derivatives_collapsed",

--- a/src/taylor_mode/__init__.py
+++ b/src/taylor_mode/__init__.py
@@ -1,11 +1,12 @@
 from .jet import Jet
-from .forward import forward_derivatives
+from .forward import forward_derivatives, hessian
 from .randomize import stochastic_laplacian
 from .collapse import forward_derivatives_collapsed
 
 __all__ = [
     "Jet",
     "forward_derivatives",
+    "hessian",
     "stochastic_laplacian",
     "forward_derivatives_collapsed",
 ]

--- a/src/taylor_mode/forward.py
+++ b/src/taylor_mode/forward.py
@@ -29,3 +29,8 @@ def forward_derivatives(
         derivs[n] = cur_fn(x)
 
     return value, derivs
+
+def hessian(f: Callable[[jnp.ndarray], jnp.ndarray], x: jnp.ndarray) -> jnp.ndarray:
+    """Convenience wrapper to return the Hessian matrix of ``f`` at ``x``."""
+    _, derivs = forward_derivatives(f, x, order=2)
+    return derivs[2]

--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -1,0 +1,9 @@
+import jax.numpy as jnp
+from taylor_mode import hessian
+
+
+def test_hessian_quadratic():
+    f = lambda x: jnp.sum(x**2)
+    x0 = jnp.array([1.0, -1.0])
+    hess = hessian(f, x0)
+    assert jnp.allclose(hess, 2 * jnp.eye(2))

--- a/tests/test_randomize.py
+++ b/tests/test_randomize.py
@@ -1,0 +1,10 @@
+import jax.numpy as jnp
+from taylor_mode import stochastic_laplacian
+
+
+def test_stochastic_laplacian_quadratic():
+    f = lambda x: jnp.sum(x**2)
+    x0 = jnp.zeros(2)
+    est = stochastic_laplacian(f, x0, samples=50)
+    # Laplacian of x^2 + y^2 is 4
+    assert jnp.allclose(est, 4.0, atol=0.5)


### PR DESCRIPTION
## Summary
- add `hessian` helper in `taylor_mode.forward`
- re-export `hessian` in package `__init__`
- add tests for `hessian` and `stochastic_laplacian`
- include new notebook demo for stochastic Laplacian

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c64bd47a88333b78a10f4aa31060d