### PR TITLE
Add simple MLP utilities and KFAC example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with
 pip install -e .
 ```
 
-This will make the `taylor_mode`, `kron_utils`, and `pinns` modules
+This will make the `taylor_mode`, `kron_utils`, `networks`, and `pinns` modules
 available.
 
 ## Example
@@ -23,3 +23,4 @@ Several notebooks in the `notebooks/` folder demonstrate the library.
 `02_gradient_operator.ipynb` demonstrates computing gradients using Taylor-mode utilities.
 `04_PINN_loss_demo.ipynb` shows building a simple Poisson PINN using `pinn_loss`.
 `08_KFAC_implementation.ipynb` shows a short linear-regression example using the `KFACOptimizer`.
+`10_pinn_with_kfac.ipynb` demonstrates training a tiny PINN using the KFAC optimizer and the simple MLP utilities from `networks`.

--- a/notebooks/10_pinn_with_kfac.ipynb
+++ b/notebooks/10_pinn_with_kfac.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PINN Training with KFAC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from networks import init_mlp, mlp_apply\n",
+    "from pinns import pinn_loss\n",
+    "from kron_utils import KFACOptimizer\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Collocation and boundary points\n",
+    "X_res = jnp.linspace(0.0, jnp.pi, 25).reshape(-1, 1)\n",
+    "X_bc = jnp.array([[0.0], [jnp.pi]])\n",
+    "bc_vals = jnp.array([0.0, 0.0])\n",
+    "forcing = lambda x: -jnp.sin(x)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "key = jax.random.PRNGKey(0)\n",
+    "params = init_mlp([1, 16, 16, 1], key)\n",
+    "opt = KFACOptimizer(lr=0.05)\n",
+    "state = opt.init([w for w, _ in params])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def model(ps, x):\n",
+    "    return mlp_apply(ps, x)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def step(ps, opt_state):\n",
+    "    def loss_fn(p_list):\n",
+    "        full_params = [(p_list[i], params[i][1]) for i in range(len(p_list))]\n",
+    "        return pinn_loss(lambda z: model(full_params, z), X_res, X_bc, bc_vals, forcing)\n",
+    "    w_list = [w for w, _ in ps]\n",
+    "    loss, grads = jax.value_and_grad(loss_fn)(w_list)\n",
+    "    preds = jax.vmap(lambda z: model(ps, z))(X_res)\n",
+    "    acts = [X_res] * len(ps)\n",
+    "    backprops = [jnp.tile(loss, (X_res.shape[0], 1))] * len(ps)\n",
+    "    new_ws, new_state = opt.step(w_list, grads, acts, backprops, opt_state)\n",
+    "    new_ps = [(new_ws[i], ps[i][1]) for i in range(len(ps))]\n",
+    "    return loss, new_ps, new_state\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "for i in range(50):\n",
+    "    loss, params, state = step(params, state)\n",
+    "loss
+"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -9,6 +9,7 @@ from .taylor_mode import (
 )
 from .kron_utils import KFACOptimizer
 from .pinns import gradient, laplacian, pinn_loss
+from .networks import init_mlp, mlp_apply
 
 __all__ = [
     "Jet",
@@ -20,4 +21,6 @@ __all__ = [
     "KFACOptimizer",
     "gradient",
     "laplacian",
+    "init_mlp",
+    "mlp_apply",
 ]

--- a/src/networks/__init__.py
+++ b/src/networks/__init__.py
@@ -1,0 +1,5 @@
+"""Simple neural network utilities."""
+
+from .simple_mlp import init_mlp, mlp_apply
+
+__all__ = ["init_mlp", "mlp_apply"]

--- a/src/networks/simple_mlp.py
+++ b/src/networks/simple_mlp.py
@@ -1,0 +1,41 @@
+"""Basic MLP utilities using JAX."""
+
+from typing import Sequence, Callable, Tuple
+import jax
+import jax.numpy as jnp
+
+
+Params = Sequence[Tuple[jnp.ndarray, jnp.ndarray]]
+
+
+def init_mlp(layers: Sequence[int], key: jax.Array) -> Params:
+    """Initialize weights and biases for a fully-connected network.
+
+    Parameters
+    ----------
+    layers : Sequence[int]
+        Layer sizes including input and output dimensions.
+    key : jax.Array
+        PRNG key for initialization.
+    Returns
+    -------
+    list of (w, b)
+        Weight matrices and bias vectors.
+    """
+    params = []
+    keys = jax.random.split(key, len(layers) - 1)
+    for k, (din, dout) in zip(keys, zip(layers[:-1], layers[1:])):
+        w_key, b_key = jax.random.split(k)
+        w = jax.random.normal(w_key, (din, dout)) / jnp.sqrt(din)
+        b = jnp.zeros(dout)
+        params.append((w, b))
+    return params
+
+
+def mlp_apply(params: Params, x: jnp.ndarray, activation: Callable = jax.nn.tanh) -> jnp.ndarray:
+    """Apply an MLP to inputs ``x``."""
+    for i, (w, b) in enumerate(params):
+        x = x @ w + b
+        if i < len(params) - 1:
+            x = activation(x)
+    return x

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,0 +1,11 @@
+import jax
+import jax.numpy as jnp
+from networks import init_mlp, mlp_apply
+
+
+def test_init_and_apply_mlp():
+    key = jax.random.PRNGKey(0)
+    params = init_mlp([1, 4, 1], key)
+    x = jnp.array([[0.0]])
+    y = mlp_apply(params, x)
+    assert y.shape == (1, 1)


### PR DESCRIPTION
## Summary
- implement `networks` package with a small MLP
- export network helpers from the top level package
- document the new utilities and example in the README
- include a notebook demonstrating KFAC on a tiny PINN
- add tests for the new network module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c676e83d8833387ad7a641a71a72c