### PR TITLE
Add MLP activation helpers and example notebook

### DIFF
--- a/notebooks/05_randomized_taylor_mode.ipynb
+++ b/notebooks/05_randomized_taylor_mode.ipynb
@@ -1,0 +1,31 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Randomized Taylor-Mode"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": ["import jax\n", "import jax.numpy as jnp\n", "from taylor_mode import stochastic_laplacian\n"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": ["f = lambda x: jnp.sum(x**2)\n", "x0 = jnp.zeros(3)\n", "approx = stochastic_laplacian(f, x0, samples=100)\n", "print('approx Laplacian:', approx)\n"]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/networks/__init__.py
+++ b/src/networks/__init__.py
@@ -1,5 +1,15 @@
 """Simple neural network utilities."""
 
-from .simple_mlp import init_mlp, mlp_apply
+from .simple_mlp import (
+    init_mlp,
+    mlp_apply,
+    mlp_forward_activations,
+    mlp_backprops,
+)
 
-__all__ = ["init_mlp", "mlp_apply"]
+__all__ = [
+    "init_mlp",
+    "mlp_apply",
+    "mlp_forward_activations",
+    "mlp_backprops",
+]

--- a/src/networks/simple_mlp.py
+++ b/src/networks/simple_mlp.py
@@ -32,10 +32,82 @@ def init_mlp(layers: Sequence[int], key: jax.Array) -> Params:
     return params
 
 
-def mlp_apply(params: Params, x: jnp.ndarray, activation: Callable = jax.nn.tanh) -> jnp.ndarray:
+def mlp_apply(
+    params: Params, x: jnp.ndarray, activation: Callable = jax.nn.tanh
+) -> jnp.ndarray:
     """Apply an MLP to inputs ``x``."""
     for i, (w, b) in enumerate(params):
         x = x @ w + b
         if i < len(params) - 1:
             x = activation(x)
     return x
+
+
+def mlp_forward_activations(
+    params: Params, x: jnp.ndarray, activation: Callable = jax.nn.tanh
+) -> Tuple[jnp.ndarray, Sequence[jnp.ndarray], Sequence[jnp.ndarray]]:
+    """Forward pass that also returns activations and pre-activations.
+
+    Parameters
+    ----------
+    params : Params
+        Weight matrices and biases.
+    x : jnp.ndarray
+        Input minibatch ``(batch, in_dim)``.
+    activation : Callable, optional
+        Non-linearity, by default ``jax.nn.tanh``.
+
+    Returns
+    -------
+    Tuple containing ``output``, ``acts`` and ``preacts`` lists. ``acts[i]`` is
+    the input to layer ``i`` (after activation of the previous layer) and
+    ``preacts[i]`` is ``acts[i] @ w + b``.
+    """
+
+    acts = []
+    preacts = []
+    a = x
+    for i, (w, b) in enumerate(params):
+        acts.append(a)
+        z = a @ w + b
+        preacts.append(z)
+        if i < len(params) - 1:
+            a = activation(z)
+        else:
+            a = z
+    return a, acts, preacts
+
+
+def mlp_backprops(
+    params: Params,
+    preacts: Sequence[jnp.ndarray],
+    loss_grad: jnp.ndarray,
+    activation: Callable = jax.nn.tanh,
+) -> Sequence[jnp.ndarray]:
+    """Compute backpropagated gradients for each layer output.
+
+    Parameters
+    ----------
+    params : Params
+        Weights and biases of the network.
+    preacts : Sequence[jnp.ndarray]
+        Pre-activation values for each layer from :func:`mlp_forward_activations`.
+    loss_grad : jnp.ndarray
+        Gradient of the loss w.r.t. the network output.
+    activation : Callable, optional
+        Activation function used in the network, by default ``jax.nn.tanh``.
+
+    Returns
+    -------
+    List of gradients w.r.t. each layer's pre-activation output, ordered from
+    input to output layer.
+    """
+
+    g = loss_grad
+    backprops = []
+    for i in reversed(range(len(params))):
+        w, _ = params[i]
+        backprops.insert(0, g)
+        if i > 0:
+            g = (g @ w.T) * (1.0 - jnp.tanh(preacts[i - 1]) ** 2)
+    return backprops

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,6 +1,11 @@
 import jax
 import jax.numpy as jnp
-from networks import init_mlp, mlp_apply
+from networks import (
+    init_mlp,
+    mlp_apply,
+    mlp_forward_activations,
+    mlp_backprops,
+)
 
 
 def test_init_and_apply_mlp():
@@ -9,3 +14,24 @@ def test_init_and_apply_mlp():
     x = jnp.array([[0.0]])
     y = mlp_apply(params, x)
     assert y.shape == (1, 1)
+
+
+def test_forward_and_backprops_match_gradients():
+    key = jax.random.PRNGKey(0)
+    params = init_mlp([1, 2, 1], key)
+    X = jnp.ones((3, 1))
+    y_true = jnp.zeros((3, 1))
+
+    def loss_fn(ps):
+        preds = mlp_apply(ps, X)
+        return jnp.mean((preds - y_true) ** 2)
+
+    loss, grads = jax.value_and_grad(loss_fn)(params)
+
+    preds, acts, preacts = mlp_forward_activations(params, X)
+    loss_grad = (preds - y_true) * (2 / X.shape[0])
+    backprops = mlp_backprops(params, preacts, loss_grad)
+    weight_grads = [acts[i].T @ backprops[i] for i in range(len(params))]
+
+    for g_est, g_true in zip(weight_grads, [g[0] for g in grads]):
+        assert jnp.allclose(g_est, g_true, atol=1e-5)


### PR DESCRIPTION
## Summary
- extend `simple_mlp` with utilities to record layer activations and compute backpropagated gradients
- export the new helpers from the `networks` package
- test that the new helpers reproduce JAX gradients
- add `05_randomized_taylor_mode.ipynb` demonstrating stochastic Laplacian

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c68d322c483339512e682b7ee8662