### PR TITLE
Add KFAC training helper and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ pip install -e .
 ```
 
 This will make the `taylor_mode`, `kron_utils`, `networks`, and `pinns` modules
-available.
+available. The `pinns` module now also exposes a simple `train_pinn` routine
+for quick experiments with KFAC training.
 
 ## Example
 
@@ -24,3 +25,4 @@ Several notebooks in the `notebooks/` folder demonstrate the library.
 `04_PINN_loss_demo.ipynb` shows building a simple Poisson PINN using `pinn_loss`.
 `08_KFAC_implementation.ipynb` shows a short linear-regression example using the `KFACOptimizer`.
 `10_pinn_with_kfac.ipynb` demonstrates training a tiny PINN using the KFAC optimizer and the simple MLP utilities from `networks`.
+`11_kfac_training.ipynb` shows the `train_pinn` helper in action.

--- a/notebooks/11_kfac_training.ipynb
+++ b/notebooks/11_kfac_training.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# KFAC PINN Training"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from networks import init_mlp\n",
+    "from kron_utils import KFACOptimizer\n",
+    "from pinns import train_pinn\n",
+    "\n",
+    "X_res = jnp.linspace(0.0, jnp.pi, 25).reshape(-1, 1)\n",
+    "X_bc = jnp.array([[0.0], [jnp.pi]])\n",
+    "bc_vals = jnp.array([0.0, 0.0])\n",
+    "forcing = lambda x: -jnp.sin(x)\n",
+    "\n",
+    "key = jax.random.PRNGKey(0)\n",
+    "params = init_mlp([1, 16, 16, 1], key)\n",
+    "opt = KFACOptimizer(lr=0.05)\n",
+    "trained = train_pinn(params, X_res, X_bc, bc_vals, forcing, opt, steps=10)\n",
+    "trained[0][0].shape\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,7 @@ from .taylor_mode import (
     forward_derivatives_collapsed,
 )
 from .kron_utils import KFACOptimizer
-from .pinns import gradient, laplacian, pinn_loss
+from .pinns import gradient, laplacian, pinn_loss, train_pinn
 from .networks import init_mlp, mlp_apply
 
 __all__ = [
@@ -23,4 +23,5 @@ __all__ = [
     "laplacian",
     "init_mlp",
     "mlp_apply",
+    "train_pinn",
 ]

--- a/src/pinns/__init__.py
+++ b/src/pinns/__init__.py
@@ -1,4 +1,5 @@
 from .loss import pinn_loss
 from .operators import gradient, laplacian
+from .trainer import train_pinn
 
-__all__ = ["gradient", "laplacian", "pinn_loss"]
+__all__ = ["gradient", "laplacian", "pinn_loss", "train_pinn"]

--- a/src/pinns/trainer.py
+++ b/src/pinns/trainer.py
@@ -1,0 +1,51 @@
+"""Simple training loop using the KFAC optimizer for PINNs."""
+
+from typing import Callable, Sequence, Tuple
+import jax
+import jax.numpy as jnp
+
+from networks import mlp_apply, mlp_forward_activations, mlp_backprops
+from kron_utils import KFACOptimizer
+from .loss import pinn_loss
+
+Params = Sequence[Tuple[jnp.ndarray, jnp.ndarray]]
+
+
+def train_pinn(
+    params: Params,
+    X_res: jnp.ndarray,
+    X_bc: jnp.ndarray,
+    bc_values: jnp.ndarray,
+    forcing_fn: Callable[[jnp.ndarray], jnp.ndarray],
+    optimizer: KFACOptimizer,
+    steps: int = 100,
+) -> Params:
+    """Train ``params`` to solve Poisson-like equations using KFAC.
+
+    The training is intentionally minimal and meant for demonstration.
+    """
+
+    opt_state = optimizer.init([w.T for w, _ in params])
+
+    def model(ps, x):
+        return mlp_apply(ps, x)
+
+    for _ in range(steps):
+
+        def loss_fn(ws):
+            ps = [(ws[i], params[i][1]) for i in range(len(ws))]
+            return pinn_loss(lambda z: model(ps, z), X_res, X_bc, bc_values, forcing_fn)
+
+        w_list = [w.T for w, _ in params]
+        loss, grads = jax.value_and_grad(loss_fn)([w for w, _ in params])
+        grads = [g.T for g in grads]
+
+        # Very rough approximations for Kronecker factors
+        preds, acts, preacts = mlp_forward_activations(params, X_res)
+        loss_grad = jnp.tile(loss, (X_res.shape[0], 1))
+        backprops = mlp_backprops(params, preacts, loss_grad)
+
+        new_ws, opt_state = optimizer.step(w_list, grads, acts, backprops, opt_state)
+        params = [(new_ws[i].T, params[i][1]) for i in range(len(params))]
+
+    return params

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,0 +1,30 @@
+import jax
+import jax.numpy as jnp
+from networks import init_mlp, mlp_apply
+from kron_utils import KFACOptimizer
+from pinns import pinn_loss, train_pinn
+
+
+def test_train_pinn_reduces_loss():
+    key = jax.random.PRNGKey(0)
+    params = init_mlp([1, 4, 1], key)
+
+    X_res = jnp.linspace(0.0, jnp.pi, 5).reshape(-1, 1)
+    X_bc = jnp.array([[0.0], [jnp.pi]])
+    bc_vals = jnp.array([0.0, 0.0])
+    forcing = lambda x: -jnp.sin(x)
+
+    opt = KFACOptimizer(lr=0.05)
+
+    def model(ps, x):
+        return mlp_apply(ps, x)
+
+    loss_fn = lambda ps: pinn_loss(
+        lambda z: model(ps, z), X_res, X_bc, bc_vals, forcing
+    )
+
+    loss_before = loss_fn(params)
+    trained = train_pinn(params, X_res, X_bc, bc_vals, forcing, opt, steps=2)
+    loss_after = loss_fn(trained)
+
+    assert loss_after < loss_before


### PR DESCRIPTION
## Summary
- create `train_pinn` helper for quick PINN training with KFAC
- expose `train_pinn` in package modules
- add example notebook demonstrating training helper
- document helper in README
- test that training reduces PINN loss

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c7808e2508333b8005251d484cda5