### PR TITLE
Add Poisson residual helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ pip install -e .
 
 This will make the `taylor_mode`, `kron_utils`, `networks`, and `pinns` modules
 available. The `pinns` module now also exposes a simple `train_pinn` routine
-for quick experiments with KFAC training.
+for quick experiments with KFAC training.  The `pinns.operators` submodule
+includes helpers like `poisson_residual` for assembling common PDE losses.
 
 ## Example
 
@@ -26,3 +27,5 @@ Several notebooks in the `notebooks/` folder demonstrate the library.
 `08_KFAC_implementation.ipynb` shows a short linear-regression example using the `KFACOptimizer`.
 `10_pinn_with_kfac.ipynb` demonstrates training a tiny PINN using the KFAC optimizer and the simple MLP utilities from `networks`.
 `11_kfac_training.ipynb` shows the `train_pinn` helper in action.
+`12_poisson_residual_demo.ipynb` demonstrates computing Poisson residuals with
+the new convenience function.

--- a/notebooks/12_poisson_residual_demo.ipynb
+++ b/notebooks/12_poisson_residual_demo.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# Demonstration of `poisson_residual`"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": ["import jax\n", "import jax.numpy as jnp\n", "from pinns.operators import poisson_residual\n"]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": ["model = lambda x: jnp.sin(x)\n", "forcing = lambda x: -jnp.sin(x)\n", "x = jnp.linspace(0.0, jnp.pi, 5).reshape(-1, 1)\n", "poisson_residual(model, x, forcing)"]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/pinns/operators.py
+++ b/src/pinns/operators.py
@@ -1,5 +1,6 @@
 from typing import Callable
 
+import jax
 import jax.numpy as jnp
 
 from taylor_mode.forward import forward_derivatives
@@ -16,3 +17,30 @@ def gradient(f: Callable[[jnp.ndarray], jnp.ndarray], x: jnp.ndarray) -> jnp.nda
     """Compute gradient of scalar function at ``x`` using Taylor-mode."""
     _, derivs = forward_derivatives(f, x, order=1)
     return derivs[1]
+
+
+def poisson_residual(
+    model: Callable[[jnp.ndarray], jnp.ndarray],
+    x: jnp.ndarray,
+    forcing_fn: Callable[[jnp.ndarray], jnp.ndarray],
+) -> jnp.ndarray:
+    """Return the Poisson residual ``Δu(x) - f(x)`` for ``model`` at ``x``.
+
+    Parameters
+    ----------
+    model : Callable
+        Neural network mapping inputs ``x`` to scalar outputs ``u(x)``.
+    x : jnp.ndarray
+        Collocation points where the residual is evaluated.
+    forcing_fn : Callable
+        Forcing term ``f(x)`` of the Poisson equation ``Δu = f``.
+
+    Returns
+    -------
+    jnp.ndarray
+        Residual values ``Δu(x) - f(x)`` at each point in ``x``.
+    """
+
+    lap_fn = lambda z: laplacian(lambda y: model(y).squeeze(), z)
+    lap_vals = jax.vmap(lap_fn)(x)
+    return lap_vals - jax.vmap(forcing_fn)(x).squeeze()

--- a/tests/test_pinns.py
+++ b/tests/test_pinns.py
@@ -1,5 +1,6 @@
 import jax.numpy as jnp
 from pinns import gradient, laplacian
+from pinns.operators import poisson_residual
 
 
 def test_gradient_and_laplacian():
@@ -22,3 +23,11 @@ def test_pinn_loss_zero_for_exact_solution():
 
     loss = pinn_loss(model, X_res, X_bc, bc_vals, forcing)
     assert loss < 1e-6
+
+
+def test_poisson_residual_zero_for_exact_solution():
+    model = lambda x: jnp.sin(x)
+    forcing = lambda x: -jnp.sin(x)
+    x = jnp.linspace(0.0, jnp.pi, 5).reshape(-1, 1)
+    res = poisson_residual(model, x, forcing)
+    assert jnp.allclose(res, 0.0)


### PR DESCRIPTION
## Summary
- implement `poisson_residual` helper in `pinns.operators`
- provide a small demonstration notebook
- document new helper in README
- test new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7befa5cc8333811d6f603ba328a3