### PR TITLE
Add heat equation residual helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ available. The `pinns` module now also exposes a simple `train_pinn` routine
 for quick experiments with KFAC training.  The `pinns.operators` submodule
 includes helpers like `poisson_residual` for assembling common PDE losses.
 
+The operators module now also provides `heat_residual` for the 1D heat
+equation, making it easy to experiment with time-dependent problems.
+
 ## Example
 
 Several notebooks in the `notebooks/` folder demonstrate the library.
@@ -29,3 +32,5 @@ Several notebooks in the `notebooks/` folder demonstrate the library.
 `11_kfac_training.ipynb` shows the `train_pinn` helper in action.
 `12_poisson_residual_demo.ipynb` demonstrates computing Poisson residuals with
 the new convenience function.
+`13_heat_residual_demo.ipynb` shows how to evaluate the heat equation residual
+using `heat_residual`.

--- a/notebooks/13_heat_residual_demo.ipynb
+++ b/notebooks/13_heat_residual_demo.ipynb
@@ -1,0 +1,27 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Heat Residual Demo"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "import jax.numpy as jnp\nfrom pinns.operators import heat_residual\n\nmodel = lambda xt: jnp.exp(-xt[1]) * jnp.sin(xt[0])\nxt = jnp.array([[0.1, 0.2]])\nprint('residual', heat_residual(model, xt))"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/pinns/__init__.py
+++ b/src/pinns/__init__.py
@@ -1,5 +1,5 @@
 from .loss import pinn_loss
-from .operators import gradient, laplacian
+from .operators import gradient, laplacian, heat_residual
 from .trainer import train_pinn
 
-__all__ = ["gradient", "laplacian", "pinn_loss", "train_pinn"]
+__all__ = ["gradient", "laplacian", "heat_residual", "pinn_loss", "train_pinn"]

--- a/src/pinns/operators.py
+++ b/src/pinns/operators.py
@@ -44,3 +44,42 @@ def poisson_residual(
     lap_fn = lambda z: laplacian(lambda y: model(y).squeeze(), z)
     lap_vals = jax.vmap(lap_fn)(x)
     return lap_vals - jax.vmap(forcing_fn)(x).squeeze()
+
+
+def heat_residual(
+    model: Callable[[jnp.ndarray], jnp.ndarray],
+    xt: jnp.ndarray,
+    diffusivity: float = 1.0,
+    forcing_fn: Callable[[jnp.ndarray], jnp.ndarray] | None = None,
+) -> jnp.ndarray:
+    """Return the heat equation residual ``u_t - α u_xx - f``.
+
+    Parameters
+    ----------
+    model : Callable
+        Network taking ``(x, t)`` concatenated as a 1D array and returning
+        ``u(x, t)``.
+    xt : jnp.ndarray
+        Points of shape ``(batch, 2)`` where the residual is evaluated.
+    diffusivity : float, optional
+        Diffusion coefficient ``α`` in the heat equation, by default ``1.0``.
+    forcing_fn : Callable, optional
+        Optional forcing term ``f(x, t)``. If ``None``, the equation is assumed
+        homogeneous.
+
+    Returns
+    -------
+    jnp.ndarray
+        Residual values at each point in ``xt``.
+    """
+
+    def single_residual(z: jnp.ndarray) -> jnp.ndarray:
+        val, derivs = forward_derivatives(lambda y: model(y).squeeze(), z, order=2)
+        grad = derivs[1]
+        hess = derivs[2]
+        res = grad[1] - diffusivity * hess[0, 0]
+        if forcing_fn is not None:
+            res = res - forcing_fn(z)
+        return res
+
+    return jax.vmap(single_residual)(xt)

--- a/tests/test_pinns.py
+++ b/tests/test_pinns.py
@@ -31,3 +31,12 @@ def test_poisson_residual_zero_for_exact_solution():
     x = jnp.linspace(0.0, jnp.pi, 5).reshape(-1, 1)
     res = poisson_residual(model, x, forcing)
     assert jnp.allclose(res, 0.0)
+
+
+def test_heat_residual_zero_for_exact_solution():
+    from pinns import heat_residual
+
+    model = lambda xt: jnp.exp(-xt[1]) * jnp.sin(xt[0])
+    xt = jnp.array([[0.1, 0.2], [0.3, 0.0]])
+    res = heat_residual(model, xt)
+    assert jnp.allclose(res, 0.0, atol=1e-6)


### PR DESCRIPTION
## Summary
- implement `heat_residual` operator for 1D heat equation
- expose new helper in package namespace
- document the operator in README and add demonstration notebook
- test that the new residual vanishes for a known solution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7d5e32a083339d829ac7fe4480cc