### PR TITLE
Add Burgers residual operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ for quick experiments with KFAC training.  The `pinns.operators` submodule
 includes helpers like `poisson_residual` for assembling common PDE losses.
 
 The operators module now also provides `heat_residual` for the 1D heat
-equation, making it easy to experiment with time-dependent problems.
+equation, and `burgers_residual` for Burgers' equation, making it easy
+to experiment with time-dependent problems.
 
 ## Example
 
@@ -34,3 +35,5 @@ Several notebooks in the `notebooks/` folder demonstrate the library.
 the new convenience function.
 `13_heat_residual_demo.ipynb` shows how to evaluate the heat equation residual
 using `heat_residual`.
+`14_burgers_residual_demo.ipynb` illustrates evaluating the Burgers equation
+residual with `burgers_residual`.

--- a/notebooks/14_burgers_residual_demo.ipynb
+++ b/notebooks/14_burgers_residual_demo.ipynb
@@ -1,0 +1,27 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Burgers Residual Demo"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "import jax.numpy as jnp\nfrom pinns.operators import burgers_residual\n\nmodel = lambda xt: 0.0\nxt = jnp.array([[0.1, 0.2]])\nprint('residual', burgers_residual(model, xt))"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/pinns/__init__.py
+++ b/src/pinns/__init__.py
@@ -1,5 +1,12 @@
 from .loss import pinn_loss
-from .operators import gradient, laplacian, heat_residual
+from .operators import gradient, laplacian, heat_residual, burgers_residual
 from .trainer import train_pinn
 
-__all__ = ["gradient", "laplacian", "heat_residual", "pinn_loss", "train_pinn"]
+__all__ = [
+    "gradient",
+    "laplacian",
+    "heat_residual",
+    "burgers_residual",
+    "pinn_loss",
+    "train_pinn",
+]

--- a/tests/test_pinns.py
+++ b/tests/test_pinns.py
@@ -40,3 +40,12 @@ def test_heat_residual_zero_for_exact_solution():
     xt = jnp.array([[0.1, 0.2], [0.3, 0.0]])
     res = heat_residual(model, xt)
     assert jnp.allclose(res, 0.0, atol=1e-6)
+
+
+def test_burgers_residual_zero_for_constant_solution():
+    from pinns.operators import burgers_residual
+
+    model = lambda xt: jnp.array(0.0)
+    xt = jnp.array([[0.0, 0.0], [0.5, 0.2]])
+    res = burgers_residual(model, xt)
+    assert jnp.allclose(res, 0.0)


### PR DESCRIPTION
## Summary
- extend operators with `burgers_residual` for 1D Burgers equation
- export `burgers_residual` from `pinns`
- document new utility in README
- provide a demonstration notebook
- test the new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c809ec70883339f7274af9e16f5ea