### PR TITLE
Add RNG seeding utilities

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for reproducibility and other small tasks."""
+
+from .random import seed_rng
+
+__all__ = ["seed_rng"]

--- a/src/utils/random.py
+++ b/src/utils/random.py
@@ -1,0 +1,15 @@
+"""Random number utility functions."""
+
+from __future__ import annotations
+
+import random
+import numpy as np
+import jax
+
+
+def seed_rng(seed: int) -> jax.Array:
+    """Seed Python, NumPy, and return a JAX PRNG key."""
+    random.seed(seed)
+    np.random.seed(seed)
+    key = jax.random.PRNGKey(seed)
+    return key

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import random
+import numpy as np
+import jax
+from utils import seed_rng
+
+
+def test_seed_rng_determinism():
+    key1 = seed_rng(0)
+    py_rand1 = random.random()
+    np_rand1 = np.random.rand()
+    jax_rand1 = jax.random.uniform(key1)
+
+    key2 = seed_rng(0)
+    py_rand2 = random.random()
+    np_rand2 = np.random.rand()
+    jax_rand2 = jax.random.uniform(key2)
+
+    assert py_rand1 == py_rand2
+    assert np.allclose(np_rand1, np_rand2)
+    assert jax_rand1 == jax_rand2


### PR DESCRIPTION
## Summary
- add `utils` package with `seed_rng` function
- test RNG seeding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c829930948333975b598c0e8d2e0e