### PR TITLE
Implement divergence operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ pip install -e .
 This will make the `taylor_mode`, `kron_utils`, `networks`, and `pinns` modules
 available. The `pinns` module now also exposes a simple `train_pinn` routine
 for quick experiments with KFAC training.  The `pinns.operators` submodule
-includes helpers like `poisson_residual` for assembling common PDE losses.
+includes helpers like `poisson_residual` for assembling common PDE losses,
+as well as convenience functions such as `divergence`.
 
 The operators module now also provides `heat_residual` for the 1D heat
 equation, and `burgers_residual` for Burgers' equation, making it easy

--- a/src/pinns/__init__.py
+++ b/src/pinns/__init__.py
@@ -1,10 +1,17 @@
 from .loss import pinn_loss
-from .operators import gradient, laplacian, heat_residual, burgers_residual
+from .operators import (
+    gradient,
+    laplacian,
+    divergence,
+    heat_residual,
+    burgers_residual,
+)
 from .trainer import train_pinn
 
 __all__ = [
     "gradient",
     "laplacian",
+    "divergence",
     "heat_residual",
     "burgers_residual",
     "pinn_loss",

--- a/src/pinns/operators.py
+++ b/src/pinns/operators.py
@@ -19,6 +19,26 @@ def gradient(f: Callable[[jnp.ndarray], jnp.ndarray], x: jnp.ndarray) -> jnp.nda
     return derivs[1]
 
 
+def divergence(f: Callable[[jnp.ndarray], jnp.ndarray], x: jnp.ndarray) -> jnp.ndarray:
+    """Return the divergence of a vector field ``f`` at ``x``.
+
+    Parameters
+    ----------
+    f : Callable
+        Function mapping inputs ``x`` to a vector output ``f(x)``.
+    x : jnp.ndarray
+        Point at which the divergence is computed.
+
+    Returns
+    -------
+    jnp.ndarray
+        Scalar divergence value ``trace(J_f(x))``.
+    """
+
+    jac = jax.jacfwd(f)(x)
+    return jnp.trace(jac)
+
+
 def poisson_residual(
     model: Callable[[jnp.ndarray], jnp.ndarray],
     x: jnp.ndarray,

--- a/tests/test_pinns.py
+++ b/tests/test_pinns.py
@@ -1,5 +1,5 @@
 import jax.numpy as jnp
-from pinns import gradient, laplacian
+from pinns import gradient, laplacian, divergence
 from pinns.operators import poisson_residual
 
 
@@ -10,6 +10,13 @@ def test_gradient_and_laplacian():
     lap = laplacian(f, x0)
     assert jnp.allclose(grad, 1.0)
     assert jnp.allclose(lap, 0.0)
+
+
+def test_divergence_simple_linear_field():
+    f = lambda x: jnp.stack([2 * x[0], x[0] + x[1]])
+    x0 = jnp.array([1.0, 2.0])
+    div = divergence(f, x0)
+    assert jnp.allclose(div, 3.0)
 
 
 def test_pinn_loss_zero_for_exact_solution():


### PR DESCRIPTION
## Summary
- implement `divergence` helper in `pinns.operators`
- re-export `divergence` from the pinns package
- document `divergence` in the README
- add a unit test exercising the new operator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc2371a5883338926f59cb6bd5003