### PR TITLE
Improve LQ FBSDE docs

### DIFF
--- a/src/fbsde/lq.py
+++ b/src/fbsde/lq.py
@@ -9,12 +9,47 @@ import jax.numpy as jnp
 
 
 def riccati_solution(
-    mu: float, sigma: float, Q: float, R: float, G: float, T: float, N: int
+    mu: float,
+    sigma: float,
+    Q: float,
+    R: float,
+    G: float,
+    T: float,
+    N: int,
 ) -> jnp.ndarray:
-    """Solve the Riccati equation backward in time.
+    r"""Solve the scalar Riccati equation.
 
-    Returns an array ``P`` of shape ``(N+1,)`` with ``P[i]`` approximating
-    ``P(t_i)`` where ``t_i = i * T / N``.
+    The equation solved is
+
+    .. math::
+
+        -\dot{P}(t) = 2\mu P(t) + \sigma^2 P(t)^2 + Q - 2R P(t),
+
+    with terminal condition ``P(T) = G``.  Euler integration with ``N`` steps
+    is used to compute an approximation.
+
+    Parameters
+    ----------
+    mu : float
+        Drift coefficient of the forward SDE.
+    sigma : float
+        Diffusion coefficient of the forward SDE.
+    Q : float
+        State cost weight.
+    R : float
+        Control cost weight.
+    G : float
+        Terminal cost weight ``P(T)``.
+    T : float
+        Final time.
+    N : int
+        Number of time steps.
+
+    Returns
+    -------
+    jnp.ndarray
+        Array ``P`` of shape ``(N+1,)`` with ``P[i]`` approximating
+        ``P(t_i)`` where ``t_i = i * T / N``.
     """
 
     dt = T / N
@@ -42,7 +77,53 @@ def solve_lq_fbsde(
     N: int,
     key: jax.Array,
 ) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
-    """Simulate a linear-quadratic FBSDE with Euler discretization."""
+    r"""Simulate a linear-quadratic FBSDE with Euler discretisation.
+
+    The forward process satisfies
+
+    .. math::
+
+        X_{t+\Delta t} = X_t + \mu X_t \Delta t + \sigma \Delta W_t,
+
+    while the backward variables are
+
+    .. math::
+
+        Y_t = P(t) X_t, \qquad Z_t = \sigma P(t) X_t,
+
+    where ``P`` is obtained from :func:`riccati_solution`.
+
+    Parameters
+    ----------
+    mu : float
+        Drift coefficient of the forward SDE.
+    sigma : float
+        Diffusion coefficient of the forward SDE.
+    Q : float
+        State cost weight.
+    R : float
+        Control cost weight.
+    G : float
+        Terminal cost weight ``P(T)``.
+    x0 : float
+        Initial state ``X_0``.
+    T : float
+        Final time.
+    N : int
+        Number of time steps.
+    key : jax.Array
+        PRNG key used to generate Brownian increments.
+
+    Returns
+    -------
+    tuple of jnp.ndarray
+        ``times``, ``X``, ``Y`` and ``Z`` arrays of shape ``(N+1,)``.
+
+    Notes
+    -----
+    Currently only a single path of the process is simulated, so the
+    returned arrays all have length ``N+1``.
+    """
 
     dt = T / N
     times = jnp.linspace(0.0, T, N + 1)

--- a/tests/test_fbsde_docs.py
+++ b/tests/test_fbsde_docs.py
@@ -1,0 +1,16 @@
+import fbsde
+from fbsde.lq import riccati_solution, solve_lq_fbsde
+
+
+def test_riccati_solution_docstring():
+    doc = riccati_solution.__doc__
+    assert doc is not None
+    assert "Riccati" in doc
+    assert "-\\dot{P}(t)" in doc
+
+
+def test_solve_lq_fbsde_docstring():
+    doc = solve_lq_fbsde.__doc__
+    assert doc is not None
+    assert "single path" in doc
+    assert "(N+1,)" in doc


### PR DESCRIPTION
## Summary
- document the linear quadratic FBSDE helper functions
- mention single-path simulation
- test that docstrings contain the new information

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8b33a4c08333bfd9665996bcb3c8