### PR TITLE
Enable vectorised simulation in LQ FBSDE solver

### DIFF
--- a/tests/test_fbsde.py
+++ b/tests/test_fbsde.py
@@ -40,11 +40,12 @@ def test_lq_fbsde_shapes():
         T=1.0,
         N=5,
         key=key,
+        num_paths=3,
     )
     assert times.shape == (6,)
-    assert X.shape == (6,)
-    assert Y.shape == (6,)
-    assert Z.shape == (6,)
+    assert X.shape == (3, 6)
+    assert Y.shape == (3, 6)
+    assert Z.shape == (3, 6)
     # Riccati consistency: Y should equal P*X
     dt = 1.0 / 5
     P = jnp.zeros(6)
@@ -59,7 +60,7 @@ def test_lq_fbsde_shapes():
 def test_lq_fbsde_solution_consistency():
     key = jax.random.PRNGKey(1)
     params = dict(mu=0.1, sigma=0.2, Q=1.0, R=0.5, G=1.0, x0=1.0, T=1.0, N=50)
-    times, X, Y, Z = solve_lq_fbsde(key=key, **params)
+    times, X, Y, Z = solve_lq_fbsde(key=key, num_paths=2, **params)
 
     P = riccati_solution(
         mu=params["mu"],
@@ -72,6 +73,7 @@ def test_lq_fbsde_solution_consistency():
     )
 
     assert times.shape == (params["N"] + 1,)
+    assert X.shape == (2, params["N"] + 1)
     assert jnp.allclose(Y, P * X, atol=1e-5)
     assert jnp.allclose(Z, params["sigma"] * P * X, atol=1e-5)
 

--- a/tests/test_fbsde_docs.py
+++ b/tests/test_fbsde_docs.py
@@ -12,5 +12,5 @@ def test_riccati_solution_docstring():
 def test_solve_lq_fbsde_docstring():
     doc = solve_lq_fbsde.__doc__
     assert doc is not None
-    assert "single path" in doc
-    assert "(N+1,)" in doc
+    assert "num_paths" in doc
+    assert "(num_paths, N+1)" in doc


### PR DESCRIPTION
## Summary
- add `num_paths` option to `solve_lq_fbsde`
- vectorise Brownian increments and forward scan
- update tests and docs for multipath capability

## Testing
- `python3 -m venv .venv && source .venv/bin/activate && pip install -q pytest jax jaxlib numpy && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8cdb7a5483339d937ec0ee47dc47